### PR TITLE
Build C code under _build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 elixir_bme680-*.tar
 
-/priv
-/src/*.o
-/src_bme280/*.o
 .elixir_ls/

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule ElixirBme680.MixProject do
       version: "0.2.1",
       elixir: "~> 1.7",
       compilers: [:elixir_make] ++ Mix.compilers,
-      aliases: aliases(),
+      make_targets: ["all"],
+      make_clean: ["clean"],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -34,10 +35,6 @@ defmodule ElixirBme680.MixProject do
       licenses: ["Apache-2.0"],
       links: %{}
     ]
-  end
-
-  defp aliases do
-    [clean: ["clean", "clean.make"]]
   end
 
   # Run "mix help deps" to learn about dependencies.


### PR DESCRIPTION
This fixes an issue where changing the MIX_TARGET would result in
incorrect binaries being used. These would immediately crash when the
port binary would run.

What was happening was that the object files and binaries were being
stored to the source directory. If the binaries were built for one
platform, `make` wouldn't know that it needed to rebuild them for the
next one. Now the object files and binaries are stored in whatever
directory under `_build` that mix is using. Mix has separate directories
for different environments and targets, so this naturally works out.