### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An Elixir library to interface with the BME680 and BME280 environmental sensors. The BME680
 provides measurements of temperature, pressure, humidity, and gas resistance
-(which is a proxy of indoor air quality). The ME680 is a lower cost device that only
+(which is a proxy of indoor air quality). The BME280 is a lower cost device that only
 provides measurements of temperature, pressure, humidity.
 
 ## Installation
@@ -24,10 +24,15 @@ The Linux I2C driver needs to be installed for this library to work (e.g.
 `libi2c-dev` on Debian). If using [Nerves](https://nerves-project.org), the
 driver should already be installed by default.
 
-## Usage with Bme680
+## Configuration
+
+Depending on your hardware configuration, you may need to specify options to `Bme680.start_link/2` or `Bme280.start_link/2`.
+For example, the i2c address of the sensor can be `0x76` or `0x77`.
+
+## Usage with the BME680
 
 ```elixir
-{:ok, pid} = Bme680.start_link()
+{:ok, pid} = Bme680.start_link(i2c_address: 0x76)
 
 measurement = Bme680.measure(pid)
 
@@ -44,10 +49,32 @@ measurement = Bme680.measure(pid)
 # relative humidity, and gas_resistance in Ohm
 ```
 
-## Usage with Bme280
+For more information, read the [API documentation](https://hexdocs.pm/elixir_bme680/Bme680.html).
+
+### Sensor compatibility
+
+The default setting has been tested on the [Pimoroni
+BME680](https://shop.pimoroni.com/products/bme680-breakout). The [Adafruit
+BME680](https://www.adafruit.com/product/3660) requires using a different i2c
+address. For the Adafruit, pass in the `i2c_address` option with value `0x77` as
+follows:
 
 ```elixir
-{:ok, pid} = Bme280.start_link()
+Bme680.start_link(i2c_address: 0x77)
+```
+
+### Note on gas resistance sensor warm up on the BME680
+
+Note that, due to the nature of the BME680 gas resistance sensor, the gas
+resistance measurement needs a warm-up in order to give stable measurements. One
+possible strategy is to perform continuous meaurements in a loop until the value
+stabilizes. That might take from a few seconds to several minutes (or more when
+the sensor is brand new).
+
+## Usage with the BME280
+
+```elixir
+{:ok, pid} = Bme280.start_link(i2c_address: 0x76)
 
 measurement = Bme280.measure(pid)
 
@@ -63,36 +90,15 @@ measurement = Bme280.measure(pid)
 # relative humidity
 ```
 
-For more information, read the [API documentation](https://hexdocs.pm/elixir_bme680).
+For more information, read the [API documentation](https://hexdocs.pm/elixir_bme680/Bme280.html).
 
-## Sensor compatibility BME680
-
-The default setting has been tested on the [Pimoroni
-BME680](https://shop.pimoroni.com/products/bme680-breakout). The [Adafruit
-BME680](https://www.adafruit.com/product/3660) requires using a different i2c
-address. For the Adafruit, pass in the `i2c_address` option with value `0x77` as
-follows:
-
-```elixir
-Bme680.start_link(i2c_address: 0x77)
-```
-
-## Sensor compatibility BME280
+### Sensor compatibility
 
 The default setting has been tested on the [HiLetgo
 BME280](https://www.amazon.com/gp/product/B01N47LZ4P/).
-
-
-## Note on gas resistance sensor warm up on the BME680
-
-Note that, due to the nature of the BME680 gas resistance sensor, the gas
-resistance measurement needs a warm-up in order to give stable measurements. One
-possible strategy is to perform continuous meaurements in a loop until the value
-stabilizes. That might take from a few seconds to several minutes (or more when
-the sensor is brand new).
 
 ## Acknowledgements
 
 This project contains low-level code from the [BME680 driver by
 Bosch](https://github.com/BoschSensortec/BME680_driver) and the
-[BME280 driver by Bosch](https://github.com/BoschSensortec/BME280_driver)
+[BME280 driver by Bosch](https://github.com/BoschSensortec/BME280_driver).

--- a/lib/elixir_bme280.ex
+++ b/lib/elixir_bme280.ex
@@ -1,6 +1,6 @@
 defmodule Bme280 do
   @moduledoc """
-  `elixir_bme280` provides a high level abstraction to interface with the
+  Provides a high level abstraction to interface with the
   BME280 environmental sensor on Linux platforms.
   """
   use Bitwise

--- a/lib/elixir_bme680.ex
+++ b/lib/elixir_bme680.ex
@@ -1,6 +1,6 @@
 defmodule Bme680 do
   @moduledoc """
-  `elixir_bme680` provides a high level abstraction to interface with the
+  Provides a high level abstraction to interface with the
   BME680 environmental sensor on Linux platforms.
   """
   use Bitwise

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule ElixirBme680.MixProject do
       package: package(),
       source_url: @source_url,
       docs: [
-        main: "Bme680",
+        main: "readme",
         extras: ["README.md"]
       ]
     ]


### PR DESCRIPTION
### Description

This is a minor improvement for the library documentation.

As a library user, I was a little confused when I first used this library. So I just thought it would be nice if I can contribute to the documentation for others.

What was confusing to to me:
- My sensor was BME680 so I wanted all the info on it in one place.
- My sensor's address happened to be `0x77`, not default `0x76`. The info on default address was not stated in the README. I wanted such important info to be highlighted so it is obvious.
- Online documentation's home page was the `Bme680` module page, which to me is not ideal because the library supports both `bme680` and `bme280`. It is nice to have higher level page. 

I guess this can be a good opportunity for improving documentation before Elixir and Nerves are going further. We could put together more ideas if any.

### Changes

- Fix some misspelling.
- Improve logical cohesion of each section of the README.
- Make the README be the landing page.